### PR TITLE
Resolve ambiguous operator for std::unique_ptr

### DIFF
--- a/src/Database.h
+++ b/src/Database.h
@@ -79,7 +79,7 @@ public:
     static void finalize (void);
     static Database & instance (void)
     {
-        if (m_instance == NULL) {
+        if (m_instance.get () == NULL) {
             g_error ("Error: Please call InputContext::init () !");
         }
         return *m_instance;


### PR DESCRIPTION
https://code.google.com/archive/p/pyzy/issues/3
# What steps will reproduce the problem?
1. extract pyzy-0.1.0 on NetBSD-6.1.4 
2. make 
3. build failure
# What is the expected output? What do you see instead?

Folowing error is happened.

```
Making all in src
/usr/bin/make all-recursive
CXX libpyzy_1_0_la-Database.lo
In file included from Database.cc:22:0:
Database.h: In static member function 'static PyZy::Database& PyZy::Database::instance()': Database.h:82:27: error: no match for 'operator==' in 'PyZy::Database::m_instance == 0'
Database.h:82:27: note: candidate is: operator==(int, int) <built-in>
* Error code 1
```
# What version of the product are you using? On what operating system?

pyzy-0.1.0 on NetBSD-6.1.4
# Please provide any additional information below.

Here are proposed fix. https://github.com/obache/pyzy/commit/5fbecb5ad3b061ff10fadb579988d409777447ab

``` patch
@@ -79,7 +79,7 @@ public:
     static void finalize (void);
     static Database & instance (void)
     {
-        if (m_instance == NULL) {
+        if (m_instance.get () == NULL) {
             g_error ("Error: Please call InputContext::init () !");
         }
         return *m_instance;
```

Use bare pointer variable to check NULL, same as Database::init() in src/Database.cc.
