### PR TITLE
ENV must not be used for path to env(1), unwanted affect to POSIX sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,10 +130,6 @@ AC_CHECK_FUNCS([uuid_create], [], [
 
 AM_CONDITIONAL(HAVE_LIBUUID, test x"$HAVE_LIBUUID" = x"yes")
 
-# check env
-AC_PATH_PROG(ENV, env)
-AC_SUBST(ENV)
-
 # --enable-boost
 AC_ARG_ENABLE(boost,
     AC_HELP_STRING([--enable-boost],


### PR DESCRIPTION
# What steps will reproduce the problem?
1. export ENV=$HOME/.shrc
2. configure
3. gmake
# What is the expected output? What do you see instead?

```
sh: Syntax error: "(" unexpected
Makefile:390: recipe for target 'config.h' failed
gmake: * [config.h] Error 2
 * Error code 2
```
# What version of the product are you using? On what operating system?

pyzy-0.1.0
NetBSD-6.1.4 with buitin /bin/sh (should be POSIX compatible)
gmake-4.0
# Please provide any additional information below.

More detailed information about this issue: http://code.google.com/p/ibus/issues/detail?id=1029

Proposed patch: https://github.com/obache/pyzy/commit/a3037689b4cc0712501bc79be329d736d733b98f 
